### PR TITLE
Add optional default-deny NetworkPolicy template.

### DIFF
--- a/templates/default-deny-network-policy.yaml
+++ b/templates/default-deny-network-policy.yaml
@@ -1,0 +1,12 @@
+{{- if eq (.Values.defaultDenyNetworkPolicy.enabled | toString) "true" }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-in-namespace-{{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -7,6 +7,15 @@ global:
   # -- The DNS entry for the cluster the chart is being rendered on with the apps. prefix
   localClusterDomain: apps.foo.cluster.com
 
+# -- Default-deny NetworkPolicy for the vault namespace
+# When enabled, deploys a namespace-wide NetworkPolicy that blocks all ingress and
+# egress for pods without an explicit allow policy. Patterns that need zero-trust
+# network isolation should enable this and provide per-pod allow rules via
+# vault.server.networkPolicy.
+# @default -- false
+defaultDenyNetworkPolicy:
+  enabled: false
+
 # -- A number of settings passed down to the vault subchart
 # @default -- depends on the individual settings
 vault:


### PR DESCRIPTION
Add optional default-deny NetworkPolicy template                                                                                                                                                                 
                                         
Add a namespace-wide default-deny NetworkPolicy that blocks all ingress
and egress for pods without an explicit allow policy. Gated by
defaultDenyNetworkPolicy.enabled (default false) so existing patterns
are unaffected.

Patterns that need zero-trust network isolation can enable this and
provide per-pod allow rules via vault.server.networkPolicy (already
supported by the upstream vault subchart).

Tested on an OpenShift 4.21 cluster with the layered-zero-trust pattern.
